### PR TITLE
Fix RSpec part of the benchmark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 
 source 'https://rubygems.org' do
   gem 'cucumber', require: false
-  gem 'rspec', '>= 3'
+  gem 'rspec-core', '~> 3.10'
+  gem 'rspec-expectations', '~> 3.10'
   gem 'minitest'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,24 +19,17 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    diff-lcs (1.3)
+    diff-lcs (1.4.4)
     gherkin (5.1.0)
     minitest (5.14.0)
     multi_json (1.14.1)
     multi_test (0.1.2)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.1)
-      rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.2)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
 
 PLATFORMS
   ruby
@@ -44,7 +37,8 @@ PLATFORMS
 DEPENDENCIES
   cucumber!
   minitest!
-  rspec (>= 3)!
+  rspec-core (~> 3.10)!
+  rspec-expectations (~> 3.10)!
 
 BUNDLED WITH
    1.17.3

--- a/bench_rspec.rb
+++ b/bench_rspec.rb
@@ -1,4 +1,5 @@
-require 'rspec'
+require 'rspec/core'
+require 'rspec/expectations'
 require 'rspec/autorun'
 
 RSpec.describe "Truth" do

--- a/bench_rspec.rb
+++ b/bench_rspec.rb
@@ -1,4 +1,5 @@
 require 'rspec'
+require 'rspec/autorun'
 
 RSpec.describe "Truth" do
   it 'should be true' do

--- a/bench_rspec.rb
+++ b/bench_rspec.rb
@@ -2,7 +2,7 @@ require 'rspec'
 require 'rspec/autorun'
 
 RSpec.describe "Truth" do
-  it 'should be true' do
-    true.should == true
+  it 'is expected be true' do
+    expect(true).to eq true
   end
 end


### PR DESCRIPTION
This PR:
1. Makes RSpec tests to actually run
2. Updates RSpec syntax to the modern one that is the mainstream in RSpec 3
3. Reduces the required RSpec libraries to the used `rspec-expectations` and `rspec-core` (and `rspec-support` underneath)

This PR **does not** make the benchmark to calculate the time it takes RSpec to actually run tests. `rspec/autorun` adds an `at_exit` hook, and in that hook the specs are run. It happens when `Benchmark.bm` has done its job.

Remark: to me, this benchmark:
 - only shows the time it takes to load up the test framework code. Divided by 100_000, the difference between the worst and the best is 30 milliseconds. (I would consider it barely noticeable)
 - it does not consider the overhead of RSpec to actually run the tests

Remark: On my non-M1 macbook, the alignment (for 1_000 iterations, too lazy to wait for 100_000) of contenders is slightly different, `cucumber` is the worst, `rspec` is in the middle, not the other way around:

```
                 user     system      total        real
cucumber:    8.861974   1.636746  10.498720 ( 11.087535)
minitest:    0.540899   0.352272   0.893171 (  0.906225)
rspec:       1.829633   0.788140   2.617773 (  2.649665)
```